### PR TITLE
.pwclientrc: Inital section is called "options"

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,7 +69,7 @@ Example
 
 ::
 
-    [base]
+    [options]
     default = patchwork
 
     [patchwork]


### PR DESCRIPTION
"base" for the initial section does not result in a working configuration.