### PR TITLE
action_info: properly handle patch properties being encoded in utf-8

### DIFF
--- a/pwclient/patches.py
+++ b/pwclient/patches.py
@@ -161,6 +161,11 @@ def action_info(rpc, patch_id):
     print(s)
     print('-' * len(s))
     for key, value in sorted(patch.items()):
+        # Some values are transferred as Binary data, these are encoded in
+        # utf-8. As of Python 3.9 xmlrpclib.Binary.__str__ however assumes
+        # latin1, so decode explicitly
+        if type(value) == xmlrpclib.Binary:
+            value = str(value.data, 'utf-8')
         print("- %- 14s: %s" % (key, value))
 
 


### PR DESCRIPTION
When a xmlrpc binary property is printed the xmlrpc module assumes it is
encoded in latin1 when converting to a string, however patchwork sends
them utf-8 encoded. So explicitly decode using utf-8.

This fixes encoding errors, for example if submitter names contain
non-ASCII chars.

Closes: https://github.com/getpatchwork/pwclient/issues/10