### PR TITLE
Allow reading pwclientrc path from environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,8 @@ Getting Started
 ---------------
 
 To use *pwclient*, you will need a ``.pwclientrc`` file, located in your home
-directory (``$HOME`` or ``~``). Patchwork itself provides sample
+directory (``$HOME`` or ``~``). You can point to another path with the
+environment variable ``PWCLIENTRC``. Patchwork itself provides sample
 ``.pwclientrc`` files for projects at ``/project/{projectName}/pwclientrc/``.
 For example, `here`__ is the ``.pwclientrc`` file for Patchwork itself.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -2,7 +2,8 @@ Configuration
 =============
 
 *pwclient* reads configuration from the ``.pwclientrc`` file, located in your
-home directory (``$HOME`` or ``~``). Patchwork itself provides sample
+home directory (``$HOME`` or ``~``). You can point to another path with the
+environment variable ``PWCLIENTRC``. Patchwork itself provides sample
 ``.pwclientrc`` files for projects at:
 
   /project/{projectName}/pwclientrc/

--- a/pwclient/shell.py
+++ b/pwclient/shell.py
@@ -17,9 +17,7 @@ from . import projects
 from . import states
 from . import utils
 
-CONFIG_FILE = os.environ.get(
-    'PWCLIENTRC',
-    os.path.expanduser('~/.pwclientrc'))
+CONFIG_FILE = os.environ.get('PWCLIENTRC', os.path.expanduser('~/.pwclientrc'))
 
 BACKEND_XMLRPC = 'xmlrpc'
 BACKEND_REST = 'rest'

--- a/pwclient/shell.py
+++ b/pwclient/shell.py
@@ -17,7 +17,9 @@ from . import projects
 from . import states
 from . import utils
 
-CONFIG_FILE = os.path.expanduser('~/.pwclientrc')
+CONFIG_FILE = os.environ.get(
+    'PWCLIENTRC',
+    os.path.expanduser('~/.pwclientrc'))
 
 BACKEND_XMLRPC = 'xmlrpc'
 BACKEND_REST = 'rest'


### PR DESCRIPTION
Path to the pwclientrc config file can now be overridden
using the PWCLIENTRC environment variable. This is useful
when the script is run by users with no home folder.

Signed-off-by: Ali Alnubani <alialnu@nvidia.com>