### PR TITLE
api: Differentiate between archive None and False

### DIFF
--- a/pwclient/api.py
+++ b/pwclient/api.py
@@ -247,7 +247,7 @@ class XMLRPC(API):
         if max_count:
             filters['max_count'] = max_count
 
-        if archived:
+        if archived is not None:
             filters['archived'] = archived
 
         if msgid:


### PR DESCRIPTION
In the patch_list() and patch_set() archived is tested without
differentiation between it being abscent or False. Improve these checks
to make it possible to request a listing of non-archived patches, as
well as setting archived to False.

Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>