### PR TITLE
allow to search by patch hash without downloading the patch

### DIFF
--- a/pwclient/api.py
+++ b/pwclient/api.py
@@ -66,6 +66,7 @@ class API(metaclass=abc.ABCMeta):
         archived,
         msgid,
         name,
+        hash,
         max_count=None,
     ):
         pass
@@ -240,6 +241,7 @@ class XMLRPC(API):
         archived,
         msgid,
         name,
+        hash,
         max_count=None,
     ):
         filters = {}
@@ -255,6 +257,9 @@ class XMLRPC(API):
 
         if name:
             filters['name__icontains'] = name
+
+        if hash:
+            filters['hash'] = hash
 
         if state is not None:
             state_id = self._state_id_by_name(state)

--- a/pwclient/parser.py
+++ b/pwclient/parser.py
@@ -97,6 +97,9 @@ def _get_filter_parser():
         '-m', '--msgid', metavar='MESSAGEID', help="filter by Message-Id"
     )
     filter_parser.add_argument(
+        '-H', '--hash', metavar='HASH', help="filter by hash"
+    )
+    filter_parser.add_argument(
         '-f',
         '--format',
         metavar='FORMAT',

--- a/pwclient/patches.py
+++ b/pwclient/patches.py
@@ -65,6 +65,7 @@ def action_list(
     archived=None,
     msgid=None,
     name=None,
+    hash=None,
     max_count=None,
     format_str=None,
 ):
@@ -75,6 +76,7 @@ def action_list(
         'archived': archived,
         'msgid': msgid,
         'name': name,
+        'hash': hash,
         'max_count': max_count,
         'submitter': None,
         'delegate': None,

--- a/pwclient/shell.py
+++ b/pwclient/shell.py
@@ -146,6 +146,7 @@ def main(argv=sys.argv[1:]):
             archived=args.archived,
             msgid=args.msgid,
             name=args.patch_name,
+            hash=args.hash,
             max_count=args.max_count,
             format_str=args.format,
         )

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -119,6 +119,7 @@ def test_action_list__no_submitter_no_delegate(mock_list_patches, capsys):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
     )
     mock_list_patches.assert_called_once_with(
@@ -150,6 +151,7 @@ def test_action_list__submitter_filter(mock_list_patches, capsys):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
     )
     mock_list_patches.assert_called_once_with(
@@ -178,6 +180,7 @@ def test_action_list__delegate_filter(mock_list_patches, capsys):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
     )
     mock_list_patches.assert_called_once_with(

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -619,6 +619,7 @@ def test_list__no_options(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -642,6 +643,7 @@ def test_list__state_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -665,6 +667,7 @@ def test_list__archived_filter(mock_action, mock_api, mock_config):
         archived=True,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -694,6 +697,7 @@ def test_list__project_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -717,6 +721,7 @@ def test_list__submitter_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -740,6 +745,7 @@ def test_list__delegate_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -763,6 +769,7 @@ def test_list__msgid_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid='fakemsgid',
         name=None,
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -786,6 +793,7 @@ def test_list__name_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name='fake patch name',
+        hash=None,
         max_count=None,
         format_str=None,
     )
@@ -809,6 +817,7 @@ def test_list__limit_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=5,
         format_str=None,
     )
@@ -832,7 +841,32 @@ def test_list__limit_reverse_filter(mock_action, mock_api, mock_config):
         archived=None,
         msgid=None,
         name=None,
+        hash=None,
         max_count=-5,
+        format_str=None,
+    )
+
+
+@mock.patch.object(utils.configparser, 'ConfigParser')
+@mock.patch.object(api, 'XMLRPC')
+@mock.patch.object(patches, 'action_list')
+def test_list__hash_filter(mock_action, mock_api, mock_config):
+
+    mock_config.return_value = FakeConfig()
+
+    shell.main(['list', '-H', '3143a71a9d33f4f12b4469818d205125cace6535'])
+
+    mock_action.assert_called_once_with(
+        mock_api.return_value,
+        project=DEFAULT_PROJECT,
+        submitter=None,
+        delegate=None,
+        state=None,
+        archived=None,
+        msgid=None,
+        name=None,
+        hash='3143a71a9d33f4f12b4469818d205125cace6535',
+        max_count=None,
         format_str=None,
     )
 


### PR DESCRIPTION
This is useful if you scan your git repository for applied patches, but hash them locally. This way you can retrieve the patchwork patch id with `pwclient`