### PR TITLE
api: Support msgid and archive fields in 'pwclient list'

### DIFF
--- a/pwclient/api.py
+++ b/pwclient/api.py
@@ -742,6 +742,12 @@ class REST(API):
         if hash is not None:
             filters['hash'] = hash
 
+        if msgid is not None:
+            filters['msgid'] = msgid
+
+        if archived is not None:
+            filters['archived'] = archived
+
         patches = self._list('patches', params=filters)
         return [self._patch_to_dict(patch) for patch in patches]
 


### PR DESCRIPTION
I regularly use commands like pwclient list -m "msgid" -f'%{id}' to find the patchwork id for a particular patch. According to the help this is supported, but the -m commandline argument is silently ignored in the REST API. Add support for this so the list command continues to work. Similarly, add support for the archive argument '-a'.