### PR TITLE
support the delegate filter for REST API

### DIFF
--- a/pwclient/api.py
+++ b/pwclient/api.py
@@ -747,6 +747,9 @@ class REST(API):
         if archived is not None:
             filters['archived'] = archived
 
+        if delegate is not None:
+            filters['delegate'] = delegate
+
         patches = self._list('patches', params=filters)
         return [self._patch_to_dict(patch) for patch in patches]
 


### PR DESCRIPTION
The REST API does not add the delegate filter to the REST API query, which
makes using -d give unexpected results:

If you add -d <something> then you will still obtain all patches, and then
print them out sorted by delegate.

Fix this by passing the delegate as a filter to the query command.

I suspect this was not implemented before because the REST API may not
actually allow partial names for the delegate. I believe this is still
valuable to support even if it requires strict matching against the
delegate names or IDs.

If a match is desirable, this could be refactored to query the set of
delegates from the API, find all the IDs which match, and then make
multiple calls to _list for each matching delegate ID. I did not attempt to
implement that.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>
